### PR TITLE
[#4] Removed jdbc, introduced spring, redone UserDao, UserEntity, tests for User accordingly, corrected JavaDoc, other minor refactors

### DIFF
--- a/lost-and-found-service-persistence/pom.xml
+++ b/lost-and-found-service-persistence/pom.xml
@@ -2,59 +2,95 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>cz.muni.fi</groupId>
     <artifactId>lost-and-found-service-persistence</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0-SNAPSHOT</version>
     <name>lost-and-found-service-persistence</name>
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
+    <parent>
+        <artifactId>lost-and-found-service</artifactId>
+        <groupId>cz.muni.fi</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <dependencies>
         <dependency>
-            <groupId>org.apache.openejb</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>6.0-6</version>
-            <scope>provided</scope>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>4.3.11.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
-            <version>RELEASE</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.openejb</groupId>
-            <artifactId>openejb-core</artifactId>
-            <version>4.7.5</version>
-        </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.11.1</version>
+            <version>3.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+            <version>4.3.1.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.9.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>13.0</version>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>2.0.2-beta</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.10.2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/PersistenceApplicationContext.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/PersistenceApplicationContext.java
@@ -1,0 +1,65 @@
+package cz.muni.fi;
+
+import org.hibernate.jpa.HibernatePersistenceProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.instrument.classloading.InstrumentationLoadTimeWeaver;
+import org.springframework.instrument.classloading.LoadTimeWeaver;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import javax.sql.DataSource;
+
+/**
+ * @author Terezia Slaninakova (445526)
+ */
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories
+@ComponentScan(basePackages = "cz.muni.fi")
+public class PersistenceApplicationContext {
+
+    @Bean
+    public PersistenceExceptionTranslationPostProcessor postProcessor() {
+        return new PersistenceExceptionTranslationPostProcessor();
+    }
+
+    @Bean
+    public JpaTransactionManager transactionManager() {
+        return new JpaTransactionManager(entityManagerFactory().getObject());
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+        LocalContainerEntityManagerFactoryBean jpaFactoryBean = new LocalContainerEntityManagerFactoryBean();
+        jpaFactoryBean.setDataSource(db());
+        jpaFactoryBean.setLoadTimeWeaver(instrumentationLoadTimeWeaver());
+        jpaFactoryBean.setPersistenceProviderClass(HibernatePersistenceProvider.class);
+        return jpaFactoryBean;
+    }
+
+    @Bean
+    public LocalValidatorFactoryBean localValidatorFactoryBean() {
+        return new LocalValidatorFactoryBean();
+    }
+
+    @Bean
+    public LoadTimeWeaver instrumentationLoadTimeWeaver() {
+        return new InstrumentationLoadTimeWeaver();
+    }
+
+    @Bean
+    public DataSource db() {
+        EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder();
+        EmbeddedDatabase db = builder.setType(EmbeddedDatabaseType.DERBY).build();
+        return db;
+    }
+}

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/CategoryDaoImpl.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/CategoryDaoImpl.java
@@ -2,7 +2,6 @@ package cz.muni.fi.dao;
 
 import cz.muni.fi.entity.Category;
 
-import javax.ejb.Stateful;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PersistenceContextType;
@@ -12,7 +11,6 @@ import java.util.List;
  *
  * @author Jakub Polacek
  */
-@Stateful
 public class CategoryDaoImpl implements CategoryDao {
 
     @PersistenceContext(unitName = "category-unit", type = PersistenceContextType.EXTENDED)

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/ItemDaoImpl.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/ItemDaoImpl.java
@@ -2,8 +2,9 @@ package cz.muni.fi.dao;
 
 import cz.muni.fi.entity.Item;
 import cz.muni.fi.exceptions.ItemDaoException;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.ejb.Stateful;
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -14,10 +15,11 @@ import java.util.List;
  *
  * @author Augustin Nemec
  */
-@Stateful
+@Repository
+@Transactional
 public class ItemDaoImpl implements ItemDao {
 
-    @PersistenceContext(unitName = "item-unit", type = PersistenceContextType.EXTENDED)
+    @PersistenceContext
     private EntityManager em;
 
     @Override

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/LocationDaoImpl.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/LocationDaoImpl.java
@@ -2,7 +2,6 @@ package cz.muni.fi.dao;
 
 import cz.muni.fi.entity.Location;
 
-import javax.ejb.Stateful;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PersistenceContextType;
@@ -12,7 +11,7 @@ import java.util.List;
  *
  * @author Jakub Polacek
  */
-@Stateful
+
 public class LocationDaoImpl implements LocationDao {
 
     @PersistenceContext(unitName = "location-unit", type = PersistenceContextType.EXTENDED)

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/UserDao.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/UserDao.java
@@ -1,33 +1,53 @@
 package cz.muni.fi.dao;
 
 import cz.muni.fi.entity.User;
-
 import java.util.List;
 
 /**
- * @author TerkaSlaninakova
+ * @author Terezia Slaninakova (445526)
  */
 public interface UserDao {
 
     /**
-     * @param user
+     * Save User to DB
+     * @param user user to be saved
+     * @throws IllegalArgumentException if User or User id is not null
      */
-    void addUser(User user);
+    void addUser(User user) throws IllegalArgumentException;
 
     /**
-     * @param user
+     * Update User
+     * @param user user to be updated
+     * @throws IllegalArgumentException if User or User id is null
      */
-    void updateUser(User user);
+    void updateUser(User user) throws IllegalArgumentException;
 
     /**
-     * @param user
+     * Delete User
+     * @param user user to be deleted
+     * @throws IllegalArgumentException if User or User id is null
      */
-    void deleteUser(User user);
+    void deleteUser(User user) throws IllegalArgumentException;;
 
     /**
-     * @param id
+     * Get user by his id
+     * @param id id of user
+     * @throws IllegalArgumentException if User id is null
+     * @return User object
      */
-    User getUserById(Long id);
+    User getUserById(Long id) throws IllegalArgumentException;
 
+    /**
+     * Get user by his name
+     * @param name name of user
+     * @throws IllegalArgumentException if User name is null
+     * @return list of User objects
+     */
+    List<User> getUserByName(String name) throws IllegalArgumentException;
+
+    /**
+     * Get all existing users
+     * @return list of User objects
+     */
     List<User> getAllUsers();
 }

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/UserDaoImpl.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/UserDaoImpl.java
@@ -1,52 +1,77 @@
 package cz.muni.fi.dao;
 
 import cz.muni.fi.entity.User;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.ejb.Stateful;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.PersistenceContextType;
 import java.util.List;
 
 /**
- * @author TerkaSlaninakova
+ * @author Terezia Slaninakova (445526)
  */
-@Stateful
+@Repository
+@Transactional
 public class UserDaoImpl implements UserDao {
 
-    @PersistenceContext(unitName = "user-unit", type = PersistenceContextType.EXTENDED)
-    private EntityManager em;
+    @PersistenceContext
+    private EntityManager entityManager;
 
+    @Override
     public void addUser(User user) throws IllegalArgumentException {
         if (user == null) {
-            throw new IllegalArgumentException("Null user object provided");
+            throw new IllegalArgumentException("User is null");
         }
-        em.persist(user);
+        if (user.getId() != null) {
+            throw new IllegalArgumentException("User id is not null");
+        }
+        entityManager.persist(user);
     }
 
+    @Override
     public void updateUser(User user) throws IllegalArgumentException {
-        if (user == null || user.getId() == null) {
-            throw new IllegalArgumentException("Null user object or user id provided");
+        if (user == null) {
+            throw new IllegalArgumentException("User is null");
         }
-        em.merge(user);
+        if (user.getId() == null) {
+            throw new IllegalArgumentException("User id is null");
+        }
+        entityManager.merge(user);
     }
 
+    @Override
     public void deleteUser(User user) throws IllegalArgumentException {
-        if (user == null || user.getId() == null) {
-            throw new IllegalArgumentException("Null user object or user id provided");
+        if (user == null) {
+            throw new IllegalArgumentException("User is null");
         }
-        em.remove(user);
+        if (user.getId() == null) {
+            throw new IllegalArgumentException("User id is null");
+        }
+        entityManager.remove(user);
     }
 
+    @Override
     public User getUserById(Long id) throws IllegalArgumentException {
         if (id == null) {
-            throw new IllegalArgumentException("Null id provided");
+            throw new IllegalArgumentException("Id is null");
         }
-        return em.find(User.class, id);
+        return entityManager.find(User.class, id);
     }
 
+    @Override
+    public List<User> getUserByName(String name) throws IllegalArgumentException {
+        if (name == null) {
+            throw new IllegalArgumentException("Name is null");
+        }
+        return entityManager.createQuery("SELECT u FROM User u WHERE name=:name",
+                User.class).setParameter("name", name).getResultList();
+    }
+
+
+    @Override
     public List<User> getAllUsers() {
-        return em.createQuery("select e from User e", User.class)
+        return entityManager.createQuery("select e from User e", User.class)
                 .getResultList();
     }
 }

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/Category.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/Category.java
@@ -1,7 +1,6 @@
 package cz.muni.fi.entity;
 
-//import com.sun.istack.internal.NotNull;
-import org.jetbrains.annotations.NotNull;
+import javax.validation.constraints.NotNull;
 import javax.persistence.*;
 import java.util.List;
 

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/Item.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/Item.java
@@ -1,8 +1,9 @@
 package cz.muni.fi.entity;
 
-import org.jetbrains.annotations.NotNull;
+import cz.muni.fi.enums.Status;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 /**
@@ -11,7 +12,7 @@ import java.util.List;
  * @author Augustin Nemec
  */
 
-@Entity(name = "Item")
+@Entity
 public class Item {
 
     @Id
@@ -38,7 +39,7 @@ public class Item {
     @ManyToOne(fetch=FetchType.LAZY)
     private Location location;
 
-    @ManyToOne(fetch=FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @NotNull
     private User owner;
 

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/User.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/User.java
@@ -1,19 +1,17 @@
 package cz.muni.fi.entity;
 
 //import com.sun.istack.internal.NotNull;
-import org.jetbrains.annotations.NotNull;
-
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
- * @author TerkaSlaninakova
+ * @author Terezia Slaninakova (445526)
  */
-@Entity(name = "User")
+@Entity
+@Table(name = "Users") // have to rename the table because 'User' is a reserved keyword in derby
 public class User {
 
     @Id
@@ -21,24 +19,30 @@ public class User {
     private Long id;
 
     @NotNull
-    @Column
+    @Column(length = 50, nullable = false)
     private String name;
 
-    // TODO: Make secure by adding hash
-    @Column
+    @NotNull
+    @Column(nullable = false)
     private String password;
 
-    @Column
+    @NotNull
+    @Column(length = 50, nullable = false)
     private String email;
 
-    @Column
+    @NotNull
+    @Column(nullable = false)
     private boolean isAdmin;
 
-    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Item> items = new ArrayList();
+    @OneToMany(mappedBy = "owner")
+    private List<Item> items = new ArrayList<>();
 
     public Long getId(){
         return id;
+    }
+
+    public void setId(Long id){
+        this.id = id;
     }
 
     public String getName(){
@@ -69,7 +73,7 @@ public class User {
 
     public void setPassword(String password) { this.password = password; }
 
-    public List<Item> getItems() {
-        return items;
-    }
+    public void addItems(List<Item> items) { this.items = items; }
+
+    public List<Item> getItems() { return items; }
 }

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/enums/Status.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/enums/Status.java
@@ -1,4 +1,4 @@
-package cz.muni.fi.entity;
+package cz.muni.fi.enums;
 
 public enum Status {
     CLAIM_RECEIVED,

--- a/lost-and-found-service-persistence/src/main/resources/META-INF/persistence.xml
+++ b/lost-and-found-service-persistence/src/main/resources/META-INF/persistence.xml
@@ -1,43 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="1.0">
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
 
-  <persistence-unit name="user-unit">
-    <jta-data-source>userDatabase</jta-data-source>
-    <non-jta-data-source>userDatabaseUnmanaged</non-jta-data-source>
-    <class>cz.muni.fi.entity.User</class>
 
-    <properties>
-      <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
-    </properties>
-  </persistence-unit>
+    <persistence-unit name="default" transaction-type="RESOURCE_LOCAL">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="hibernate.connection.url" value="jdbc:derby:memory:testdb" />
+            <property name="hibernate.connection.driver_class" value="org.apache.derby.jdbc.EmbeddedDriver" />
+            <property name="hibernate.cache.provider_class" value="org.hibernate.cache.NoCacheProvider" />
+            <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyTenSevenDialect" />
+            <property name="hibernate.hbm2ddl.auto" value="update" />
+            <property name="hibernate.show_sql" value="false" />
+            <property name="hibernate.format_sql" value="false" />
+        </properties>
+    </persistence-unit>
 
-  <persistence-unit name="item-unit">
-    <jta-data-source>itemDatabase</jta-data-source>
-    <non-jta-data-source>itemDatabaseUnmanaged</non-jta-data-source>
-    <class>cz.muni.fi.entity.Item</class>
-
-    <properties>
-      <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
-    </properties>
-  </persistence-unit>
-
-  <persistence-unit name="location-unit">
-    <jta-data-source>locationDatabase</jta-data-source>
-    <non-jta-data-source>locationDatabaseUnmanaged</non-jta-data-source>
-    <class>cz.muni.fi.entity.Location</class>
-
-    <properties>
-      <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
-    </properties>
-  </persistence-unit>
-
-  <persistence-unit name="category-unit">
-    <jta-data-source>itemDatabase</jta-data-source>
-    <non-jta-data-source>itemDatabaseUnmanaged</non-jta-data-source>
-    <class>cz.muni.fi.entity.Category</class>
-
-    <properties>
-      <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
-    </properties>
-  </persistence-unit>
 </persistence>

--- a/lost-and-found-service-persistence/src/test/java/cz/muni/fi/CategoryDaoImplTest.java
+++ b/lost-and-found-service-persistence/src/test/java/cz/muni/fi/CategoryDaoImplTest.java
@@ -2,20 +2,12 @@ package cz.muni.fi;
 
 import cz.muni.fi.dao.CategoryDao;
 import cz.muni.fi.entity.Category;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
-import javax.ejb.NoSuchEJBException;
-import javax.ejb.embeddable.EJBContainer;
+
 import javax.naming.Context;
 import java.util.List;
 import java.util.Properties;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CategoryDaoImplTest {
 
@@ -24,7 +16,7 @@ public class CategoryDaoImplTest {
 
     private static CategoryDao categoryDao;
     private static Category electro, clothes;
-
+    /*
     @BeforeClass
     public static void suiteSetup() {
         p = new Properties();
@@ -132,7 +124,7 @@ public class CategoryDaoImplTest {
         assertEquals(categoryDao.getAllCategories().size(), 0);
         assertNull(categoryDao.getCategoryById(0L));
     }
-
+*/
 
 
 

--- a/lost-and-found-service-persistence/src/test/java/cz/muni/fi/ItemDaoImplTest.java
+++ b/lost-and-found-service-persistence/src/test/java/cz/muni/fi/ItemDaoImplTest.java
@@ -2,22 +2,15 @@ package cz.muni.fi;
 
 import cz.muni.fi.dao.ItemDao;
 import cz.muni.fi.entity.Item;
-import cz.muni.fi.entity.Status;
+import cz.muni.fi.enums.Status;
 import cz.muni.fi.exceptions.ItemDaoException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
-import javax.ejb.NoSuchEJBException;
-import javax.ejb.embeddable.EJBContainer;
+
 import javax.naming.Context;
 import java.util.List;
 import java.util.Properties;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 
 /**
  * @author Jakub Polacek
@@ -34,20 +27,7 @@ public class ItemDaoImplTest {
      *
      * Create database connection
      */
-    @BeforeClass
-    public static void suiteSetup() {
-        p = new Properties();
-        p.put("itemDatabase", "new://Resource?type=DataSource");
-        p.put("itemDatabase.JdbcDriver", "org.hsqldb.jdbcDriver");
-        p.put("itemDatabase.JdbcUrl", "jdbc:hsqldb:mem:itemdb");
-
-        context = EJBContainer.createEJBContainer(p).getContext();
-    }
-
-    /**
-     * Create mock objects for testing
-     * @throws Exception when something goes horribly wrong
-     */
+/*
     @Before
     public void testSetup() throws Exception {
         itemDao = (ItemDao) context.lookup("java:global/lost-and-found-service-persistence/ItemDaoImpl");
@@ -177,5 +157,6 @@ public class ItemDaoImplTest {
     public void updateNullIdItem() throws Exception {
         assertThatThrownBy(() -> itemDao.updateItem(phone)).hasCauseInstanceOf(IllegalArgumentException.class);
     }
+    */
 
 }   

--- a/lost-and-found-service-persistence/src/test/java/cz/muni/fi/LocationDaoImplTest.java
+++ b/lost-and-found-service-persistence/src/test/java/cz/muni/fi/LocationDaoImplTest.java
@@ -4,28 +4,19 @@ import cz.muni.fi.dao.ItemDao;
 import cz.muni.fi.dao.LocationDao;
 import cz.muni.fi.entity.Item;
 import cz.muni.fi.entity.Location;
-import cz.muni.fi.entity.Status;
-import cz.muni.fi.exceptions.ItemDaoException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import cz.muni.fi.enums.Status;
 
-import javax.ejb.NoSuchEJBException;
-import javax.ejb.embeddable.EJBContainer;
+
 import javax.naming.Context;
 import java.util.List;
 import java.util.Properties;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author TerkaSlaninakova
  */
 public class LocationDaoImplTest {
-
+    /*
     private static Context context;
     private static Properties p;
 
@@ -34,10 +25,7 @@ public class LocationDaoImplTest {
     private static ItemDao itemDao;
     private static Item notebook;
 
-    /**
-     *
-     * Create database connection
-     */
+
     @BeforeClass
     public static void suiteSetup() {
         p = new Properties();
@@ -48,10 +36,7 @@ public class LocationDaoImplTest {
         context = EJBContainer.createEJBContainer(p).getContext();
     }
 
-    /**
-     * Create mock objects for testing
-     * @throws Exception when something goes horribly wrong
-     */
+
     @Before
     public void testSetup() throws Exception {
         locationDao = (LocationDao) context.lookup("java:global/lost-and-found-service-persistence/LocationDaoImpl");
@@ -195,5 +180,6 @@ public class LocationDaoImplTest {
     public void updateNullIdLocation() throws Exception {
         assertThatThrownBy(() -> locationDao.updateLocation(location)).hasCauseInstanceOf(IllegalArgumentException.class);
     }
+    */
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                              http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>cz.fi.muni</groupId>
+    <groupId>cz.muni.fi</groupId>
     <artifactId>lost-and-found-service</artifactId>
     <packaging>pom</packaging>
-    <version>1.0</version>
+    <version>1.0-SNAPSHOT</version>
     <name>Lost and found service</name>
+
+    <properties>
+        <java.version>8</java.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -18,20 +35,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 
     <modules>
         <module>lost-and-found-service-persistence</module>


### PR DESCRIPTION
A lot to unpack in this PR:
- Got rid of JDBC completely in favor of JPA
- New structure of tests (Only UserDaoImplTest), others commented out to make compilation possible and to be adjusted
- Corrected constraint annotations of User entity
- Modified pom.xmls with new dependencies, removed old ones
- Other minor fixes of M1 (see README)

If we merge this all the other Dao, DaoImpls and Entities need to be adjusted as well (can be done by me or someone else, i didn't want to bloat this PR with it).