### PR TITLE
Added tests for item service with mockito, Adjusted impl for item dao, entity, service layer for category, minor adjustments

### DIFF
--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/ItemDao.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/ItemDao.java
@@ -18,7 +18,7 @@ public interface ItemDao {
      * @throws IllegalArgumentException when itemEntity is null
      * @throws IllegalArgumentException when itemEntity already exists
      * */
-    void addItem(Item item) throws IllegalArgumentException;
+    Item addItem(Item item) throws IllegalArgumentException;
 
     /**
      * Delete an item.
@@ -27,7 +27,7 @@ public interface ItemDao {
      * @throws IllegalArgumentException when itemEntity is null
      * @throws IllegalArgumentException when itemEntity doesn't exist (nothing to delete)
      */
-    void deleteItem(Item item) throws IllegalArgumentException;
+    Item deleteItem(Item item) throws IllegalArgumentException;
 
     /**
      * Find item with given id.
@@ -52,6 +52,6 @@ public interface ItemDao {
      * @throws IllegalArgumentException when itemEntity is null
      * @throws IllegalArgumentException when item is not persisted yet
      * */
-    void updateItem(Item item) throws IllegalArgumentException;
+    Item updateItem(Item item) throws IllegalArgumentException;
 
 }

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/ItemDaoImpl.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/dao/ItemDaoImpl.java
@@ -18,7 +18,7 @@ public class ItemDaoImpl implements ItemDao {
     private EntityManager em;
 
     @Override
-    public void addItem(Item item) {
+    public Item addItem(Item item) {
         if (item == null) {
             throw new IllegalArgumentException("Item is null");
         }
@@ -27,11 +27,11 @@ public class ItemDaoImpl implements ItemDao {
         } catch (EntityExistsException e) {
             throw new IllegalArgumentException("Item already exists");
         }
-
+        return item;
     }
 
     @Override
-    public void deleteItem(Item item) {
+    public Item deleteItem(Item item) {
         if (item == null || item.getId() == null) {
             throw new IllegalArgumentException("Item is null");
         }
@@ -40,7 +40,7 @@ public class ItemDaoImpl implements ItemDao {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Nothing to remove");
         }
-
+        return item;
     }
 
     @Override
@@ -58,7 +58,7 @@ public class ItemDaoImpl implements ItemDao {
     }
 
     @Override
-    public void updateItem(Item item) {
+    public Item updateItem(Item item) {
         if (item == null || item.getId() == null) {
             throw new IllegalArgumentException("Item is null");
         }
@@ -67,5 +67,6 @@ public class ItemDaoImpl implements ItemDao {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Item does not exist");
         }
+        return item;
     }
 }

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/Item.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/Item.java
@@ -4,6 +4,7 @@ import cz.muni.fi.enums.Status;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
@@ -33,12 +34,21 @@ public class Item {
     @Column
     private String photo;
 
+    @Column
+    private LocalDate foundDate;
+
+    @Column
+    private String archive;
+
     @NotNull
     @Column
     private Status status;
 
     @ManyToOne
-    private Location location;
+    private Location foundLocation;
+
+    @ManyToOne
+    private Location lostLocation;
 
     @ManyToOne
     private User owner;
@@ -52,6 +62,10 @@ public class Item {
 
     public void setOwner(User owner) {
         this.owner = owner;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 
     public Long getId() {
@@ -98,12 +112,20 @@ public class Item {
         this.status = status;
     }
 
-    public Location getLocation() {
-        return location;
+    public Location getLostLocation() {
+        return this.lostLocation;
     }
 
-    public void setLocation(Location lostLocation) {
-        this.location = lostLocation;
+    public void setLostLocation(Location lostLocation) {
+        this.lostLocation = lostLocation;
+    }
+
+    public Location getFoundLocation() {
+        return this.foundLocation;
+    }
+
+    public void setFoundLocation(Location foundLocation) {
+        this.foundLocation = foundLocation;
     }
 
     public List<Category> getCategories() {
@@ -112,6 +134,22 @@ public class Item {
 
     public void setCategories(List<Category> categories) {
         this.categories = categories;
+    }
+
+    public LocalDate getFoundDate() {
+        return this.foundDate;
+    }
+
+    public void setFoundDate(LocalDate foundDate) {
+        this.foundDate = foundDate;
+    }
+
+    public String getArchive() {
+        return this.archive;
+    }
+
+    public void setArchive(String archive) {
+        this.archive = archive;
     }
 
     @Override
@@ -125,12 +163,13 @@ public class Item {
                 Objects.equals(characteristics, item.getCharacteristics()) &&
                 Objects.equals(photo, item.getPhoto()) &&
                 status == item.getStatus() &&
-                Objects.equals(location, item.getLocation()) &&
+                Objects.equals(lostLocation, item.getLostLocation()) &&
+                Objects.equals(foundLocation, item.getFoundLocation()) &&
                 Objects.equals(owner, item.getOwner());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, type, characteristics, photo, status, location, owner);
+        return Objects.hash(id, name, type, characteristics, photo, status, foundLocation, lostLocation, archive, owner);
     }
 }

--- a/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/Item.java
+++ b/lost-and-found-service-persistence/src/main/java/cz/muni/fi/entity/Item.java
@@ -165,6 +165,7 @@ public class Item {
                 status == item.getStatus() &&
                 Objects.equals(lostLocation, item.getLostLocation()) &&
                 Objects.equals(foundLocation, item.getFoundLocation()) &&
+                Objects.equals(archive, item.getArchive()) &&
                 Objects.equals(owner, item.getOwner());
     }
 

--- a/lost-and-found-service-service/pom.xml
+++ b/lost-and-found-service-service/pom.xml
@@ -14,26 +14,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>10.10.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-jpa</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>[4.3.18,)</version>
-        </dependency>
-        <dependency>
             <groupId>cz.muni.fi</groupId>
             <artifactId>lost-and-found-service-persistence</artifactId>
             <version>${project.parent.version}</version>
@@ -42,6 +22,16 @@
             <groupId>net.sf.dozer</groupId>
             <artifactId>dozer</artifactId>
             <version>5.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.craftsman</groupId>
+            <artifactId>dozer-jdk8-support</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>4.1.1.RELEASE</version>
         </dependency>
 
         <dependency>
@@ -55,6 +45,23 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>2.0.2-beta</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lost-and-found-service-service/pom.xml
+++ b/lost-and-found-service-service/pom.xml
@@ -24,11 +24,6 @@
             <version>5.5.1</version>
         </dependency>
         <dependency>
-            <groupId>io.craftsman</groupId>
-            <artifactId>dozer-jdk8-support</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
             <version>4.1.1.RELEASE</version>
@@ -45,12 +40,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>2.0.2-beta</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lost-and-found-service-service/src/main/java/cz/muni/fi/service/CategoryServiceImpl.java
+++ b/lost-and-found-service-service/src/main/java/cz/muni/fi/service/CategoryServiceImpl.java
@@ -1,0 +1,78 @@
+package cz.muni.fi.service;
+
+import cz.muni.fi.dao.CategoryDao;
+import cz.muni.fi.entity.Category;
+import cz.muni.fi.service.exceptions.ServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service layer for Category
+ * @author Terezia Slaninakova (445526)
+ */
+@Service
+public class CategoryServiceImpl implements CategoryService{
+
+    @Autowired
+    private CategoryDao categoryDao;
+
+    @Override
+    public void addCategory(Category category) throws IllegalArgumentException {
+        if (category == null) {
+            throw new IllegalArgumentException("Category");
+        }
+        try {
+            categoryDao.addCategory(category);
+        } catch (Throwable e) {
+            throw new ServiceException("Could not add category.", e);
+        }
+    }
+
+    @Override
+    public void updateCategory(Category category) throws IllegalArgumentException {
+        if (category == null || category.getId() == null) {
+            throw new IllegalArgumentException("Category or id null");
+        }
+        try {
+            categoryDao.updateCategory(category);
+        } catch (Throwable e) {
+            throw new ServiceException("Could not update category.", e);
+        }
+    }
+
+    @Override
+    public void deleteCategory(Category category) throws IllegalArgumentException {
+        if (category == null || category.getId() == null) {
+            throw new IllegalArgumentException("Category or id null");
+        }
+        try {
+            categoryDao.deleteCategory(category);
+        } catch (Throwable e) {
+            throw new ServiceException("Could not delete category.", e);
+        }
+    }
+
+    @Override
+    public Category getCategoryById(Long id) throws IllegalArgumentException {
+        if (id == null) {
+            throw new IllegalArgumentException("Null id");
+        }
+        try {
+            return categoryDao.getCategoryById(id);
+        } catch (Throwable e) {
+            throw new ServiceException("Could not get category by id.", e);
+        }
+    }
+
+    @Override
+    public List<Category> getAllCategories() {
+        try {
+            return categoryDao.getAllCategories();
+        } catch (Throwable e) {
+            throw new ServiceException("Could not get all categories.", e);
+        }
+    }
+}

--- a/lost-and-found-service-service/src/main/java/cz/muni/fi/service/ItemService.java
+++ b/lost-and-found-service-service/src/main/java/cz/muni/fi/service/ItemService.java
@@ -2,6 +2,7 @@ package cz.muni.fi.service;
 
 import cz.muni.fi.entity.Item;
 import org.springframework.dao.DataAccessException;
+import java.time.LocalDate;
 
 import java.util.List;
 
@@ -10,14 +11,27 @@ import java.util.List;
  * @author Terezia Slaninakova (445526)
  */
 public interface ItemService {
+
+    /**
+     * Archives an item
+     *
+     * @param item - itemEntity to be archived
+     * @throws IllegalArgumentException when itemEntity is null
+     * @throws DataAccessException when itemEntity cannot be archived
+     *
+     * @return archived item
+     * */
+    Item archiveItem(Item item, LocalDate foundDate) throws DataAccessException;
+
     /**
      * Create a new item.
      *
      * @param item - itemEntity to be added
      * @throws IllegalArgumentException when itemEntity is null
      * @throws DataAccessException when itemEntity already exists
+     * @return added item
      * */
-    void addItem(Item item) throws DataAccessException;
+    Item addItem(Item item) throws DataAccessException;
 
     /**
      * Delete an item.
@@ -25,8 +39,9 @@ public interface ItemService {
      * @param item - itemEntity to be deleted
      * @throws IllegalArgumentException when itemEntity is null
      * @throws DataAccessException when itemEntity doesn't exist (nothing to delete)
+     * @return deleted item
      */
-    void deleteItem(Item item) throws DataAccessException;
+    Item deleteItem(Item item) throws DataAccessException;
 
     /**
      * Find item with given id.
@@ -50,6 +65,8 @@ public interface ItemService {
      * @param item - itemEntity to be updated
      * @throws IllegalArgumentException when itemEntity is null
      * @throws DataAccessException when item is not persisted yet
+     *
+     * @return updated item
      * */
-    void updateItem(Item item) throws DataAccessException;
+    Item updateItem(Item item) throws DataAccessException;
 }

--- a/lost-and-found-service-service/src/main/java/cz/muni/fi/service/ItemServiceImpl.java
+++ b/lost-and-found-service-service/src/main/java/cz/muni/fi/service/ItemServiceImpl.java
@@ -1,0 +1,116 @@
+package cz.muni.fi.service;
+
+import cz.muni.fi.dao.ItemDao;
+import cz.muni.fi.entity.Item;
+import cz.muni.fi.service.exceptions.ServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityExistsException;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Service layer for Item
+ * @author Terezia Slaninakova (445526)
+ */
+@Service
+public class ItemServiceImpl implements ItemService {
+
+    @Autowired
+    private ItemDao itemDao;
+
+    @Override
+    public Item archiveItem(Item item, LocalDate foundDate) {
+        if (item == null) {
+            throw new IllegalArgumentException("Item cannot be null");
+        }
+        if (foundDate == null) {
+            throw new IllegalArgumentException("Found date cannot be null");
+        }
+        if (foundDate.isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("Found date must be set into the past");
+        }
+        item.setFoundDate(foundDate);
+
+        item.setArchive("{ 'Item': {" +
+                    " 'name': '" + item.getName() +"'," +
+                    " 'characteristics': '" + item.getCharacteristics() + "'," +
+                    " 'photo': '" + item.getPhoto() + "'," +
+                    " 'type': '" + item.getType() + "'," +
+                    " 'foundDate': '" + item.getFoundDate().toString() + "'," +
+                    " 'id': '" + item.getId() + "'," +
+                    " 'categories' " + item.getCategories() + "'," +
+                    " 'lostLocation': '" + item.getLostLocation() + "'," +
+                    " 'foundLocation': '" + item.getFoundLocation() + "'," +
+                    " 'owner': '" + item.getOwner() + "'," +
+                    " 'status': '" + item.getStatus() + "'," +
+                    "}}");
+        try {
+            itemDao.updateItem(item);
+        } catch (EntityExistsException e) {
+            throw new ServiceException("Could not archive Item", e);
+        }
+        return item;
+    }
+
+    @Override
+    public Item addItem(Item item) {
+        if (item == null) {
+            throw new IllegalArgumentException("Item is null");
+        }
+        try {
+            itemDao.addItem(item);
+        } catch (EntityExistsException e) {
+            throw new ServiceException("Could not add Item", e);
+        }
+        return item;
+    }
+
+    @Override
+    public Item deleteItem(Item item) {
+        if (item == null || item.getId() == null) {
+            throw new IllegalArgumentException("Item is null");
+        }
+        try {
+            itemDao.deleteItem(item);
+        } catch (EntityExistsException e) {
+            throw new ServiceException("Could not delete Item", e);
+        }
+        return item;
+    }
+
+    @Override
+    public Item getItembyId(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("Item's id is null");
+        }
+        try {
+            return itemDao.getItembyId(id);
+        } catch (EntityExistsException e) {
+            throw new ServiceException("Could not delete Item", e);
+        }
+    }
+
+    @Override
+    public List<Item> getAllItems() {
+        try {
+            return itemDao.getAllItems();
+        } catch (EntityExistsException e) {
+            throw new ServiceException("Could not get all items", e);
+        }
+    }
+
+    @Override
+    public Item updateItem(Item item) {
+        if (item == null || item.getId() == null) {
+            throw new IllegalArgumentException("Item is null");
+        }
+        try {
+            itemDao.updateItem(item);
+        } catch (EntityExistsException e) {
+            throw new ServiceException("Could not get all items", e);
+        }
+        return item;
+    }
+}

--- a/lost-and-found-service-service/src/test/java/cz.muni.fi.service/ItemServiceTest.java
+++ b/lost-and-found-service-service/src/test/java/cz.muni.fi.service/ItemServiceTest.java
@@ -1,0 +1,159 @@
+package cz.muni.fi.service;
+
+import cz.muni.fi.dao.ItemDao;
+import cz.muni.fi.entity.Item;
+import cz.muni.fi.enums.Status;
+import cz.muni.fi.service.config.ServiceConfiguration;
+import org.hibernate.service.spi.ServiceException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for ItemService
+ * @author Terezia Slaninakova (445526)
+ */
+@ContextConfiguration(classes = ServiceConfiguration.class)
+public class ItemServiceTest extends AbstractTestNGSpringContextTests {
+    @Mock
+    private ItemDao itemDao;
+
+    @Autowired
+    @InjectMocks
+    private ItemService itemService = new ItemServiceImpl();
+
+    private Item itemWallet;
+    private Item itemUmbrella;
+    private Item itemJacket;
+
+    private Long itemCounter = 10L;
+    private Map<Long, Item> items = new HashMap<>();
+
+    @BeforeClass
+    public void beforeClass() throws ServiceException {
+        MockitoAnnotations.initMocks(this);
+        // mocks
+        when(itemDao.addItem(any(Item.class))).then(invoke -> {
+            Item mockedItem = invoke.getArgumentAt(0, Item.class);
+            if (mockedItem == null) {
+                throw new IllegalArgumentException("Item can't be null");
+            }
+            long id = itemCounter++;
+            mockedItem.setId(id);
+            items.put(id, mockedItem);
+            return mockedItem;
+        });
+        when(itemDao.updateItem(any(Item.class))).then(invoke -> {
+            Item mockedItem = invoke.getArgumentAt(0, Item.class);
+            if (mockedItem == null || mockedItem.getId() == null) {
+                throw new IllegalArgumentException("Item or item's id can't be null");
+            }
+            items.replace(mockedItem.getId(), mockedItem);
+            return mockedItem;
+        });
+        when(itemDao.deleteItem(any(Item.class))).then(invoke -> {
+            Item mockedItem = invoke.getArgumentAt(0, Item.class);
+            if (mockedItem == null || mockedItem.getId() == null) {
+                throw new IllegalArgumentException("Item or item's id can't be null");
+            }
+            items.remove(mockedItem.getId(), mockedItem);
+            return mockedItem;
+        });
+        when(itemDao.getAllItems()).then(invoke -> new ArrayList<>(items.values()));
+
+        when(itemDao.getItembyId(anyLong())).then(invoke -> {
+            Long index = invoke.getArgumentAt(0, Long.class);
+            if (index == null) {
+                throw new IllegalArgumentException("Item can't be null");
+            }
+            return items.get(index);
+        });
+    }
+
+    @BeforeMethod
+    public void beforeTest() {
+        items.clear();
+        itemWallet = new Item();
+        itemWallet.setName("Leather wallet");
+        itemWallet.setId(1L);
+        itemUmbrella = new Item();
+        itemUmbrella.setName("Red umbrella");
+        itemUmbrella.setId(2L);
+        itemJacket = new Item();
+        itemJacket.setName("Winter black jacket");
+        itemJacket.setId(3L);
+
+        itemJacket.setStatus(Status.CLAIM_RECEIVED);
+        itemUmbrella.setStatus(Status.IN_PROGRESS);
+        itemWallet.setStatus(Status.FOUND);
+        itemWallet.setFoundDate(LocalDate.now().minusDays(1));
+
+        items.put(1L, itemWallet);
+        items.put(2L, itemUmbrella);
+        items.put(3L, itemJacket);
+    }
+
+    @Test
+    public void testAddItem() {
+        int originalSize = items.size();
+        itemService.addItem(itemWallet);
+        assertThat(items.values()).hasSize(originalSize + 1)
+                .contains(itemWallet);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testAddNullItem() {
+        itemService.addItem(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUpdateNullItem() {
+        itemService.updateItem(null);
+    }
+
+    @Test
+    public void testGetAllItems()  {
+        assertThat(itemService.getAllItems()).containsExactlyInAnyOrder(itemJacket, itemUmbrella, itemWallet);
+    }
+
+    @Test
+    public void testGetItemById()  {
+        assertThat(itemService.getItembyId(itemJacket.getId())).isEqualToComparingFieldByField(itemJacket);
+    }
+
+    @Test
+    public void testDeleteItem() {
+        int originalSize = items.size();
+        itemService.deleteItem(itemWallet);
+        assertThat(items.values()).hasSize(originalSize - 1)
+                .doesNotContain(itemWallet);
+    }
+
+    @Test
+    public void testUpdateItem() {
+        String updatedName = "Updated jacket";
+        itemJacket.setName(updatedName);
+        Item updatedJacket = items.get(itemJacket.getId());
+        itemService.updateItem(itemJacket);
+        assertThat(updatedJacket.getName()).isEqualTo(updatedName);
+        assertThat(updatedJacket).isEqualToComparingFieldByField(itemJacket);
+    }
+
+    // TODO: Add more tests (archive, negative, special cases)
+}


### PR DESCRIPTION
Service layer
- dependencies for tests in pom.xml
- implementations for ItemService and CategoryService
- tests for service layer methods set up based on seminars

Persistence layer adjustments
- return type of dao methods returning null to allow the use of mocking behavior using when()
- setId() in Item for mocking purposes
- found/lost location, foundDate on found item, archive property used in service layer
- adjusted hash/equals accordingly
Note: other entities/daos will need to be adjusted accordingly when creating service layer tests for them

Missing for brevity purposes
- not all the tests implemented for Item and test suite for Category is missing, will finish in another PR